### PR TITLE
OPS-0 Adding the ability to return the ec2 security groups facts

### DIFF
--- a/tasks/create_ec2_security_group.yml
+++ b/tasks/create_ec2_security_group.yml
@@ -70,3 +70,8 @@
     aws_access_key: "{{ lookup('ENV', 'AWS_SECRET_KEY') | default(omit) }}"
     security_token: "{{ lookup('ENV', 'AWS_SECURITY_TOKEN') | default(omit) }}"
     profile: "{{ aws_ec2_security_group_profile | default(omit) }}"
+  register: _aws_ec2_security_group_facts
+
+- name: "Set GroupIds Facts"
+  set_fact:
+    facts_ec2_security_groups: "{{ ec2_security_groups + [_aws_ec2_security_group_facts.group_id] }}"

--- a/tasks/create_ec2_security_groups.yml
+++ b/tasks/create_ec2_security_groups.yml
@@ -1,6 +1,12 @@
 ---
 
 ###
+### Ensure Facts are clear
+###
+- set_fact:
+  facts_ec2_security_groups: []
+
+###
 ### Asserts
 ###
 - name: ensure ec2_security_groups array is defined correctly


### PR DESCRIPTION
# Description

Adding the ability to save the facts after the creation of the security groups, so the resultan group_ids can be used in the playbooks easily.

