### PR TITLE
OPS-0 indentation caused variable to be undefined

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -6,5 +6,11 @@ ignore: |
   /.travis.yml
 
 rules:
+  indentation:
+    level: warning
+    spaces: 2
+    indent-sequences: consistent
+    check-multi-line-strings: true
   line-length:
     max: 120
+  new-line-at-end-of-file: enable

--- a/tasks/create_ec2_security_groups.yml
+++ b/tasks/create_ec2_security_groups.yml
@@ -4,7 +4,7 @@
 ### Ensure Facts are clear
 ###
 - set_fact:
-  aws_ec2_security_groups_facts: []
+    aws_ec2_security_groups_facts: []
 
 ###
 ### Asserts


### PR DESCRIPTION
- Fixed variable indentation.
- Added more rules to yamlint to catch indentation problems