### PR TITLE
OPS-0 Adding SG Name to facts

### DIFF
--- a/tasks/create_ec2_security_group.yml
+++ b/tasks/create_ec2_security_group.yml
@@ -74,4 +74,4 @@
 
 - name: "Set GroupIds Facts"
   set_fact:
-    aws_ec2_security_groups_facts: "{{ aws_ec2_security_groups_facts + [_aws_ec2_security_group_facts.group_id] }}"
+    aws_ec2_security_groups_facts: "{{ aws_ec2_security_groups_facts | combine( {sg.name: {'group_id': _aws_ec2_security_group_facts.group_id} } )}}"

--- a/tasks/create_ec2_security_group.yml
+++ b/tasks/create_ec2_security_group.yml
@@ -74,4 +74,5 @@
 
 - name: "Set GroupIds Facts"
   set_fact:
-    aws_ec2_security_groups_facts: "{{ aws_ec2_security_groups_facts | combine( {sg.name: {'group_id': _aws_ec2_security_group_facts.group_id} } )}}"
+    aws_ec2_security_groups_facts: "{{ aws_ec2_security_groups_facts |
+    combine( {sg.name: {'group_id': _aws_ec2_security_group_facts.group_id} } )}}"


### PR DESCRIPTION
- Because it will be needed to index the right security group by kops